### PR TITLE
Fix MultiSelect Auto-Close on Query Clear

### DIFF
--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -355,7 +355,9 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
     };
 
     private handleQueryChange = (query: string, evt?: React.ChangeEvent<HTMLInputElement>) => {
-        this.setState({ isOpen: query.length > 0 || (this.props.customTarget == null && !this.props.openOnKeyDown) });
+        if (this.props.customTarget == null) {
+            this.setState({ isOpen: query.length > 0 || !this.props.openOnKeyDown });
+        }
         this.props.onQueryChange?.(query, evt);
     };
 

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -167,6 +167,46 @@ describe("<MultiSelect>", () => {
         containerElement.remove();
     });
 
+    it("does NOT close popover when clearing query if customTarget is used", async () => {
+        // Mount to document to get input focus behavior
+        const containerElement = document.createElement("div");
+        document.body.appendChild(containerElement);
+
+        const customTarget = () => <Button data-testid="custom-target-button" text="Target" />;
+        const props = {
+            customTarget,
+            popoverProps: { usePortal: false },
+        };
+
+        const wrapper = mount(<MultiSelect<Film> {...defaultProps} {...handlers} {...props} />, {
+            attachTo: containerElement,
+        });
+
+        // Open popover using custom target
+        findTargetButton(wrapper).simulate("click");
+        await delay(100);
+        wrapper.update();
+
+        // Popover should be open
+        assert.isTrue(wrapper.find(Popover).prop("isOpen"), "Popover should be open after click");
+
+        // Find input and simulate a query change to non-empty, then to empty
+        let input = wrapper.find("input");
+        input.simulate("change", { target: { value: "abc" } });
+        wrapper.update();
+        input = wrapper.find("input");
+        assert.strictEqual(input.prop("value"), "abc", "Input should have value 'abc'");
+
+        // Now simulate clearing the query
+        input.simulate("change", { target: { value: "" } });
+        wrapper.update();
+
+        // Popover should still be open
+        assert.isTrue(wrapper.find(Popover).prop("isOpen"), "Popover should remain open after clearing query");
+
+        containerElement.remove();
+    });
+
     function multiselect(props: Partial<MultiSelectProps<Film>> = {}, query?: string) {
         const wrapper = mount(
             <MultiSelect<Film> {...defaultProps} {...handlers} {...props}>


### PR DESCRIPTION
This pull request addresses issue #7423 where the MultiSelect component's popover closes automatically when the search query is cleared. The logic in the `handleQueryChange` method of the `MultiSelect` component has been modified to ensure the popover remains open when the search string is emptied while using a custom target. Additionally, a new test case has been introduced to verify that the popover does not close when clearing the query. This change will enhance user experience by allowing multiple searches without the popover closing unexpectedly.

---

> This pull request was co-created with Cosine Genie

Original Task: [blueprint/35qrqj84x6lb](https://cosine.sh/cosinedemo/blueprint/task/35qrqj84x6lb)
Author: Pandelis Zembashis
