### PR TITLE
Add aria-label support to TimePicker component

### DIFF
--- a/packages/datetime/src/components/time-picker/timePicker.tsx
+++ b/packages/datetime/src/components/time-picker/timePicker.tsx
@@ -26,7 +26,15 @@ import {
     Intent,
 } from "@blueprintjs/core";
 
-import { Classes, DateUtils, type TimePickerProps, TimePrecision } from "../../common";
+import { Classes, DateUtils, type TimePickerProps as BaseTimePickerProps, TimePrecision } from "../../common";
+
+/**
+ * Extends TimePickerProps to include ampmSelectAriaLabel for accessibility of the AM/PM selector.
+ */
+export interface TimePickerProps extends BaseTimePickerProps {
+    /** Accessibility label for the AM/PM selector */
+    ampmSelectAriaLabel?: string;
+}
 import {
     getDefaultMaxTime,
     getDefaultMinTime,
@@ -215,6 +223,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
                 disabled={this.props.disabled}
                 onChange={this.handleAmPmChange}
                 value={this.state.isPm ? "pm" : "am"}
+                aria-label={this.props.ampmSelectAriaLabel ?? "Select AM or PM"}
             >
                 <option value="am">AM</option>
                 <option value="pm">PM</option>

--- a/packages/datetime/test/components/timePickerTests.tsx
+++ b/packages/datetime/test/components/timePickerTests.tsx
@@ -43,6 +43,15 @@ describe("<TimePicker>", () => {
         containerElement.remove();
     });
 
+    it("sets custom aria-label on AM/PM select when ampmSelectAriaLabel prop is provided", () => {
+        const ariaLabel = "Select AM or PM for time";
+        renderTimePicker({ useAmPm: true, ampmSelectAriaLabel: ariaLabel });
+        // The select lives inside the HTMLSelect wrapper, which gets the TIMEPICKER_AMPM_SELECT class
+        const select = containerElement.querySelector(`.${Classes.TIMEPICKER_AMPM_SELECT} select`);
+        assert.isNotNull(select, "AM/PM select should be rendered");
+        assert.strictEqual(select?.getAttribute("aria-label"), ariaLabel, "aria-label should be set correctly");
+    });
+
     it("renders its contents", () => {
         assert.lengthOf(document.getElementsByClassName(Classes.TIMEPICKER), 0);
 


### PR DESCRIPTION
This pull request addresses issue #7483 by implementing support for an `aria-label` on the AM/PM selector of the TimePicker component for improved accessibility. We modified the `TimePickerProps` to include an optional `ampmSelectAriaLabel` prop, which is used to set the `aria-label` of the AM/PM select element. Additionally, we've added a unit test to validate that when this prop is provided, the `aria-label` is correctly applied to the select element. The test ensures that the component behaves as expected, making it more accessible to users. All tests have been run and passed successfully.

---

> This pull request was co-created with Cosine Genie

Original Task: [blueprint/ll7ru9budwud](https://cosine.wtf/demo-staging/blueprint/task/ll7ru9budwud)
Author: Pandelis Zembashis
